### PR TITLE
Implement rotating preview and fonts

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -78,6 +78,24 @@ document.addEventListener('DOMContentLoaded', function() {
   
   // Preview settings changes
   document.getElementById('font-style')?.addEventListener('change', updatePixelPreview);
+
+  // Automatically rotate messages every 5 seconds
+  setInterval(function() {
+    fetch('/api/rotate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' }
+    })
+    .then(function(res) { return res.json(); })
+    .then(function(data) {
+      if (data.success && data.current) {
+        document.getElementById('current-message-text').textContent = data.current;
+        updatePixelPreview(data.current);
+      }
+    })
+    .catch(function(err) {
+      console.error('Auto rotate error:', err);
+    });
+  }, 5000);
 });
 
 // Pixel preview initialization
@@ -135,6 +153,11 @@ function renderPixelPreview(message, fontStyle, darkMode) {
   const canvas = document.getElementById('preview-canvas');
   const ctx = canvas.getContext('2d');
   const container = document.getElementById('pixel-preview');
+
+  while (container.firstChild) {
+    container.removeChild(container.firstChild);
+  }
+  container.appendChild(canvas);
   
   // Set canvas size based on container
   canvas.width = container.clientWidth - 40; // Subtract padding

--- a/utils/pixel-preview.js
+++ b/utils/pixel-preview.js
@@ -28,7 +28,90 @@ function messageToPixels(message, options = {}) {
         [1,0,1],
         [1,0,1]
       ],
-      // Add more characters...
+      'B': [
+        [1,1,0],
+        [1,0,1],
+        [1,1,0],
+        [1,0,1],
+        [1,1,0]
+      ],
+      'C': [
+        [0,1,1],
+        [1,0,0],
+        [1,0,0],
+        [1,0,0],
+        [0,1,1]
+      ],
+      '0': [
+        [0,1,0],
+        [1,0,1],
+        [1,0,1],
+        [1,0,1],
+        [0,1,0]
+      ],
+      '1': [
+        [0,1,0],
+        [1,1,0],
+        [0,1,0],
+        [0,1,0],
+        [1,1,1]
+      ],
+      '2': [
+        [1,1,0],
+        [0,0,1],
+        [0,1,0],
+        [1,0,0],
+        [1,1,1]
+      ],
+      '3': [
+        [1,1,0],
+        [0,0,1],
+        [0,1,0],
+        [0,0,1],
+        [1,1,0]
+      ],
+      '4': [
+        [1,0,1],
+        [1,0,1],
+        [1,1,1],
+        [0,0,1],
+        [0,0,1]
+      ],
+      '5': [
+        [1,1,1],
+        [1,0,0],
+        [1,1,0],
+        [0,0,1],
+        [1,1,0]
+      ],
+      '6': [
+        [0,1,1],
+        [1,0,0],
+        [1,1,0],
+        [1,0,1],
+        [0,1,0]
+      ],
+      '7': [
+        [1,1,1],
+        [0,0,1],
+        [0,1,0],
+        [0,1,0],
+        [0,1,0]
+      ],
+      '8': [
+        [0,1,0],
+        [1,0,1],
+        [0,1,0],
+        [1,0,1],
+        [0,1,0]
+      ],
+      '9': [
+        [0,1,0],
+        [1,0,1],
+        [0,1,1],
+        [0,0,1],
+        [1,1,0]
+      ]
     },
     slim: {
       // Define a slimmer font style
@@ -37,37 +120,60 @@ function messageToPixels(message, options = {}) {
       // Define a bolder font style
     }
   };
+
+  const icons = {
+    ':NODE:': [
+      [1,0,1,0,1],
+      [1,1,0,1,1],
+      [1,0,1,0,1],
+      [1,0,1,0,1],
+      [1,0,1,0,1]
+    ],
+    ':PY:': [
+      [1,1,1,1,0],
+      [1,0,0,0,1],
+      [1,1,1,1,0],
+      [1,0,0,0,0],
+      [1,0,0,0,0]
+    ]
+  };
   
   let currentWeek = 0;
   
   // For each character in the message
   for (let i = 0; i < message.length; i++) {
+    const remaining = message.slice(i).toUpperCase();
     const char = message[i].toUpperCase();
-    
+
     // Skip if we've reached the end of available weeks
     if (currentWeek >= config.maxWidth) break;
     
-    // If we have a pixel representation for this character
-    if (fonts[config.font][char]) {
-      const charMap = fonts[config.font][char];
-      
-      // For each column of the character
+    let charMap = null;
+    let advance = 0;
+
+    if (remaining.startsWith(':NODE:')) {
+      charMap = icons[':NODE:'];
+      advance = 5; // total 6 including loop increment
+    } else if (remaining.startsWith(':PY:')) {
+      charMap = icons[':PY:'];
+      advance = 3; // total 4 including loop increment
+    } else if (fonts[config.font][char]) {
+      charMap = fonts[config.font][char];
+    }
+
+    if (charMap) {
       for (let x = 0; x < charMap[0].length; x++) {
-        // Skip if we've reached the end of available weeks
         if (currentWeek >= config.maxWidth) break;
-        
-        // For each row of the character
         for (let y = 0; y < charMap.length; y++) {
-          // Stay within bounds of GitHub's 7-day week
           if (y < config.maxHeight) {
-            result[currentWeek][y] = charMap[y][x] ? 4 : 0; // 4 is maximum intensity
+            result[currentWeek][y] = charMap[y][x] ? 4 : 0;
           }
         }
         currentWeek++;
       }
-      
-      // Add spacing between characters
+
       currentWeek += config.charSpacing;
+      i += advance;
     } else if (char === ' ') {
       // Handle spaces
       currentWeek += 2;

--- a/views/dashboard.handlebars
+++ b/views/dashboard.handlebars
@@ -7,6 +7,10 @@
   {{else}}
     <p class="text-gray-400">No current message</p>
   {{/if}}
+  <div id="pixel-preview" class="mt-4">
+    <canvas id="preview-canvas" class="mx-auto"></canvas>
+    <div id="preview-placeholder" class="text-gray-400">Loading preview...</div>
+  </div>
 </section>
 
 <section class="mb-8">


### PR DESCRIPTION
## Summary
- expand available pixel fonts and add small icon maps
- reuse preview canvas and rotate messages automatically
- add preview area to dashboard view

## Testing
- `node tests/pixel-preview.test.js`

------
https://chatgpt.com/codex/tasks/task_e_683f4d3c8c0483289b9a8355a80aa717