### PR TITLE
Improve graph preview

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -180,3 +180,13 @@ canvas {
   image-rendering: -moz-crisp-edges;
   image-rendering: crisp-edges;
 }
+
+/* Smooth text transition when messages change */
+@keyframes fadeSlide {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.message-transition {
+  animation: fadeSlide 0.5s ease;
+}

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -88,7 +88,11 @@ document.addEventListener('DOMContentLoaded', function() {
     .then(function(res) { return res.json(); })
     .then(function(data) {
       if (data.success && data.current) {
-        document.getElementById('current-message-text').textContent = data.current;
+        const el = document.getElementById('current-message-text');
+        el.classList.remove('message-transition');
+        void el.offsetWidth; // trigger reflow for restart
+        el.textContent = data.current;
+        el.classList.add('message-transition');
         updatePixelPreview(data.current);
       }
     })
@@ -110,7 +114,8 @@ function initPixelPreview() {
 function updatePixelPreview(message) {
   const currentMessage = message || document.getElementById('current-message-text')?.textContent.trim();
   if (!currentMessage || currentMessage === 'No active message') {
-    document.getElementById('preview-placeholder').classList.remove('hidden');
+    const placeholder = document.getElementById('preview-placeholder');
+    if (placeholder) placeholder.classList.remove('hidden');
     document.getElementById('preview-canvas').classList.add('hidden');
     return;
   }
@@ -119,7 +124,8 @@ function updatePixelPreview(message) {
   const isDarkMode = document.body.getAttribute('data-theme') === 'dark';
   
   // Show loading state
-  document.getElementById('preview-placeholder').classList.remove('hidden');
+  const placeholder = document.getElementById('preview-placeholder');
+  if (placeholder) placeholder.classList.remove('hidden');
   document.getElementById('preview-canvas').classList.add('hidden');
   
   // Get the preview from server
@@ -201,7 +207,8 @@ function renderPixelPreview(message, fontStyle, darkMode) {
   }
   
   // Hide placeholder, show canvas
-  document.getElementById('preview-placeholder').classList.add('hidden');
+  const placeholder = document.getElementById('preview-placeholder');
+  if (placeholder) placeholder.remove();
   document.getElementById('preview-canvas').classList.remove('hidden');
 }
 

--- a/utils/pixel-preview.js
+++ b/utils/pixel-preview.js
@@ -4,6 +4,7 @@
  * Converts a message string to a pixel pattern for GitHub contributions
  * @param {string} message - The message to render
  * @param {Object} options - Configuration options
+ * @param {number} [options.iconScale=1] - Scale factor for built-in icon tokens
  * @returns {Array} 2D array representing weeks and days with intensity values
  */
 function messageToPixels(message, options = {}) {
@@ -11,7 +12,8 @@ function messageToPixels(message, options = {}) {
     font: 'pixel',  // 'pixel', 'slim', or 'bold'
     maxWidth: 52,   // Max weeks in GitHub contribution graph
     maxHeight: 7,   // Days per week in contribution graph
-    charSpacing: 1  // Space between characters
+    charSpacing: 1, // Space between characters
+    iconScale: 1    // Scale factor for built-in icons
   };
   
   const config = { ...defaults, ...options };
@@ -137,6 +139,23 @@ function messageToPixels(message, options = {}) {
       [1,0,0,0,0]
     ]
   };
+
+  function scaleCharMap(map, scale) {
+    if (scale <= 1) return map;
+    const scaled = [];
+    for (const row of map) {
+      const scaledRow = [];
+      for (const cell of row) {
+        for (let i = 0; i < scale; i++) {
+          scaledRow.push(cell);
+        }
+      }
+      for (let i = 0; i < scale; i++) {
+        scaled.push([...scaledRow]);
+      }
+    }
+    return scaled;
+  }
   
   let currentWeek = 0;
   
@@ -152,10 +171,10 @@ function messageToPixels(message, options = {}) {
     let advance = 0;
 
     if (remaining.startsWith(':NODE:')) {
-      charMap = icons[':NODE:'];
+      charMap = scaleCharMap(icons[':NODE:'], config.iconScale);
       advance = 5; // total 6 including loop increment
     } else if (remaining.startsWith(':PY:')) {
-      charMap = icons[':PY:'];
+      charMap = scaleCharMap(icons[':PY:'], config.iconScale);
       advance = 3; // total 4 including loop increment
     } else if (fonts[config.font][char]) {
       charMap = fonts[config.font][char];

--- a/views/dashboard.handlebars
+++ b/views/dashboard.handlebars
@@ -1,11 +1,11 @@
 <section class="mb-8">
   <h2 class="text-xl font-bold mb-2">Current Message</h2>
   {{#if currentMessage}}
-    <div class="p-4 bg-green-900 rounded text-white">
+    <div id="current-message-text" class="p-4 bg-green-900 rounded text-white">
       {{currentMessage}}
     </div>
   {{else}}
-    <p class="text-gray-400">No current message</p>
+    <p id="current-message-text" class="text-gray-400">No current message</p>
   {{/if}}
   <div id="pixel-preview" class="mt-4">
     <canvas id="preview-canvas" class="mx-auto"></canvas>


### PR DESCRIPTION
## Summary
- add animation to message changes
- remove preview placeholder after render
- allow scaling icon tokens
- expose current message element for JS

## Testing
- `node tests/pixel-preview.test.js`

------
https://chatgpt.com/codex/tasks/task_e_683f510196148328a1936e266dd0ab7d